### PR TITLE
AdiSplash added spolier tags for username and password

### DIFF
--- a/main.js
+++ b/main.js
@@ -214,7 +214,7 @@ ipcMain.on('start', function (start) {
                     } else if (e.footer.text === 'AdiSplash by Backdoor, All Rights Reserved.') {
                         size = (e.fields)[1]['value']
                         userPass = (e.fields)[2]['value']
-                        email = (userPass).split(' ')[1].split('\n')[0]
+                        email = (userPass).split(': ')[1].split('\n')[0]
                         pass = (userPass).split(': ')[2]
 
                         loginURL = e.url

--- a/nogui.js
+++ b/nogui.js
@@ -149,7 +149,7 @@ function start() {
                     } else if (e.footer.text === 'AdiSplash by Backdoor, All Rights Reserved.') {
                         size = (e.fields)[1]['value']
                         userPass = (e.fields)[2]['value']
-                        email = (userPass).split(' ')[1].split('\n')[0]
+                        email = (userPass).split(': ')[1].split('\n')[0]
                         pass = (userPass).split(': ')[2]
 
                         loginURL = e.url


### PR DESCRIPTION
The lastest Adisplash update uses spoiler tags || || for the username and password sent to the cart requestor. Simple fix to the user/pass split to handle this.

Simple test/validation below:

```
$ cat app.js
userPass = 'Email: ||foo@aol.com ||\nPassword: || password123 ||'
user = (userPass).split(': ')[1].split('\n')[0]
pass = (userPass).split(': ')[2]
console.log(`${userPass}`)
console.log(`${user}`)
console.log(`${pass}`)

$ node  app.js
Email: ||foo@aol.com ||
Password: || password123 ||
||foo@aol.com ||
|| password123 ||
```
